### PR TITLE
Add task breakdown based on user needs

### DIFF
--- a/docs/tasks/01-questionnaire-builder.md
+++ b/docs/tasks/01-questionnaire-builder.md
@@ -1,0 +1,4 @@
+# Task: Dynamic Questionnaire Builder
+
+Implement an administration interface that allows creation of questionnaires composed of multiple question blocks. Administrators should be able to add, remove and reorder questions dynamically.
+

--- a/docs/tasks/02-mandatory-questions.md
+++ b/docs/tasks/02-mandatory-questions.md
@@ -1,0 +1,4 @@
+# Task: Mandatory or Optional Questions
+
+Provide a toggle for each question to mark it as required or optional. The builder should enforce completion of required questions when the form is used.
+

--- a/docs/tasks/03-question-dependencies.md
+++ b/docs/tasks/03-question-dependencies.md
@@ -1,0 +1,4 @@
+# Task: Question Dependencies
+
+Allow administrators to define conditional display logic. Based on previous answers, certain questions should appear or disappear dynamically.
+

--- a/docs/tasks/04-short-text.md
+++ b/docs/tasks/04-short-text.md
@@ -1,0 +1,4 @@
+# Task: Short Text Input
+
+Implement a short text input control with configurable minimum and maximum length. Validation should prevent submission if the input length is outside the allowed range.
+

--- a/docs/tasks/05-long-text.md
+++ b/docs/tasks/05-long-text.md
@@ -1,0 +1,4 @@
+# Task: Long Text Input
+
+Provide a textarea component that supports multi-line answers. Administrators can define minimum and maximum length limits for validation.
+

--- a/docs/tasks/06-multiple-choice.md
+++ b/docs/tasks/06-multiple-choice.md
@@ -1,0 +1,4 @@
+# Task: Multiple Choice Question
+
+Implement a checklist input where users can select one or more options. Administrators should be able to specify a minimum number of selections and optionally allow a free-form answer with length limits.
+

--- a/docs/tasks/07-single-choice.md
+++ b/docs/tasks/07-single-choice.md
@@ -1,0 +1,4 @@
+# Task: Single Choice Question
+
+Provide a radio button list where only one answer may be selected. The administrator can make selection mandatory and permit a manual entry with length restrictions.
+

--- a/docs/tasks/08-date-input.md
+++ b/docs/tasks/08-date-input.md
@@ -1,0 +1,4 @@
+# Task: Date Input Question
+
+Create a date input control that validates against optional minimum and maximum allowed dates. Administrators can decide whether providing a date is required.
+

--- a/docs/tasks/09-file-upload.md
+++ b/docs/tasks/09-file-upload.md
@@ -1,0 +1,4 @@
+# Task: File Upload Question
+
+Add a file upload control that checks file type and size. Administrators can set these limits and choose whether uploading a file is mandatory.
+

--- a/docs/tasks/10-video-link.md
+++ b/docs/tasks/10-video-link.md
@@ -1,0 +1,4 @@
+# Task: Video Link Question
+
+Provide a text field to capture a valid video URL. Validation should ensure the link matches accepted formats, and administrators can make this field required or optional.
+


### PR DESCRIPTION
## Summary
- create `docs/tasks` directory
- add individual task files for dynamic questionnaire features

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684bc32a4cd08333bc8423454db1e567