### PR TITLE
Add task documentation

### DIFF
--- a/docs/tasks/task-applicant-interface.md
+++ b/docs/tasks/task-applicant-interface.md
@@ -1,0 +1,17 @@
+# Applicant Questionnaire Interface
+
+## Description
+Create the user-facing interface where applicants complete the questionnaire. The form should dynamically display or hide questions based on the configured dependencies and enforce validations defined by administrators.
+
+## Preconditions
+- Questionnaire structure is defined by the administration interface.
+
+## Potential Errors or Edge Cases
+- Users navigating away mid-process may lose progress unless data is saved temporarily.
+- Dependency rules misconfigured by administrators could cause questions to never appear.
+
+## Related Tasks
+- [task-questionnaire-admin-interface.md](task-questionnaire-admin-interface.md)
+- [task-question-dependencies.md](task-question-dependencies.md)
+- [task-mandatory-questions.md](task-mandatory-questions.md)
+

--- a/docs/tasks/task-date-input-type.md
+++ b/docs/tasks/task-date-input-type.md
@@ -1,0 +1,14 @@
+# Date Input Question Type
+
+## Description
+Support a date input control that can restrict acceptable dates with minimum and maximum values. Administrators may also designate whether providing a date is mandatory.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Handling invalid date formats submitted by the user.
+- Dates outside the allowed range must trigger validation errors.
+
+## Related Tasks
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-file-upload-type.md
+++ b/docs/tasks/task-file-upload-type.md
@@ -1,0 +1,14 @@
+# File Upload Question Type
+
+## Description
+Provide a file upload control where administrators can specify accepted file types, maximum file size, and whether uploading is mandatory.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Uploading files larger than the allowed size must be rejected gracefully.
+- Unsupported file formats should display a helpful error message.
+
+## Related Tasks
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-long-text-type.md
+++ b/docs/tasks/task-long-text-type.md
@@ -1,0 +1,14 @@
+# Long Text Question Type
+
+## Description
+Provide a textarea control for questions that require multi-line answers. Administrators can configure the minimum and maximum length of the response.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Extremely long text may impact performance or exceed database limits.
+
+## Related Tasks
+- [task-short-text-type.md](task-short-text-type.md)
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-mandatory-questions.md
+++ b/docs/tasks/task-mandatory-questions.md
@@ -1,0 +1,14 @@
+# Mandatory and Optional Questions
+
+## Description
+Provide functionality for administrators to mark any question as mandatory or optional. The applicant interface must enforce this rule by preventing submission when mandatory questions are unanswered.
+
+## Preconditions
+- Questionnaire administration interface is available.
+
+## Potential Errors or Edge Cases
+- Changes to mandatory status after applicants begin completing the questionnaire could lead to inconsistent validations.
+
+## Related Tasks
+- [task-questionnaire-admin-interface.md](task-questionnaire-admin-interface.md)
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-multiple-choices-type.md
+++ b/docs/tasks/task-multiple-choices-type.md
@@ -1,0 +1,15 @@
+# Multiple Choices Question Type
+
+## Description
+Create a checklist control where applicants may select one or more options. Administrators can define a minimum number of options required for the answer to be valid and may allow applicants to manually enter an additional response with configurable length limits.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Failing to select the required minimum number of options should display a validation error.
+- Manual entry should respect the configured length limits.
+
+## Related Tasks
+- [task-single-choice-type.md](task-single-choice-type.md)
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-persistence-storage.md
+++ b/docs/tasks/task-persistence-storage.md
@@ -1,0 +1,17 @@
+# Questionnaire Persistence and Storage
+
+## Description
+Design the backend or storage mechanism to save questionnaire definitions and applicant responses. This task includes data models, database setup, and APIs for creating, updating, and retrieving questionnaires and answers.
+
+## Preconditions
+- Database or storage service is selected.
+
+## Potential Errors or Edge Cases
+- Schema changes may require data migrations for existing questionnaires.
+- Large file uploads could exceed storage quotas if not managed carefully.
+
+## Related Tasks
+- [task-file-upload-type.md](task-file-upload-type.md)
+- [task-questionnaire-admin-interface.md](task-questionnaire-admin-interface.md)
+- [task-applicant-interface.md](task-applicant-interface.md)
+

--- a/docs/tasks/task-question-dependencies.md
+++ b/docs/tasks/task-question-dependencies.md
@@ -1,0 +1,17 @@
+# Question Dependencies
+
+## Description
+Allow administrators to define dependencies between questions. Based on an applicant's answer to a specific question, the system should show or hide subsequent questions dynamically.
+
+## Preconditions
+- Questionnaire administration interface is implemented.
+- Applicant interface supports dynamic rendering.
+
+## Potential Errors or Edge Cases
+- Circular dependencies between questions could cause infinite loops in display logic.
+- Hidden mandatory questions should not block submission.
+
+## Related Tasks
+- [task-questionnaire-admin-interface.md](task-questionnaire-admin-interface.md)
+- [task-mandatory-questions.md](task-mandatory-questions.md)
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-questionnaire-admin-interface.md
+++ b/docs/tasks/task-questionnaire-admin-interface.md
@@ -1,0 +1,16 @@
+# Questionnaire Administration Interface
+
+## Description
+Implement an administration interface that allows administrators to build questionnaires dynamically. Administrators must be able to add questions, set the answer type from the supported list, and arrange question order. The interface should provide an overview of existing questions and allow editing or deleting them.
+
+## Preconditions
+- Administrator authentication mechanism exists.
+
+## Potential Errors or Edge Cases
+- Invalid question configurations when editing multiple questions simultaneously.
+- Unexpected loss of data if network requests fail while saving.
+
+## Related Tasks
+- [task-mandatory-questions.md](task-mandatory-questions.md)
+- [task-question-dependencies.md](task-question-dependencies.md)
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-short-text-type.md
+++ b/docs/tasks/task-short-text-type.md
@@ -1,0 +1,14 @@
+# Short Text Question Type
+
+## Description
+Implement a short text input control for questions requiring brief answers. Administrators must be able to set minimum and maximum length limits for the answer.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- User input shorter or longer than allowed limits should trigger validation messages.
+
+## Related Tasks
+- [task-long-text-type.md](task-long-text-type.md)
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-single-choice-type.md
+++ b/docs/tasks/task-single-choice-type.md
@@ -1,0 +1,14 @@
+# Single Choice Question Type
+
+## Description
+Implement a radio button list that allows only one answer selection. Administrators decide whether a selection is mandatory and may permit manual entry for missing options with configurable length limits.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Users submitting without a selection when the question is mandatory should see a validation error.
+
+## Related Tasks
+- [task-multiple-choices-type.md](task-multiple-choices-type.md)
+- [task-applicant-interface.md](task-applicant-interface.md)

--- a/docs/tasks/task-video-link-type.md
+++ b/docs/tasks/task-video-link-type.md
@@ -1,0 +1,14 @@
+# Video Link Question Type
+
+## Description
+Implement a text input that accepts a URL to a video file. Administrators can restrict valid file types and decide if providing the link is mandatory.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Invalid URLs should be flagged during validation.
+- Links pointing to unsupported video formats must be rejected.
+
+## Related Tasks
+- [task-applicant-interface.md](task-applicant-interface.md)


### PR DESCRIPTION
## Summary
- add a set of task descriptions covering administration and applicant features

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684bdecc3a90833398114b0dc79947f3