### PR TITLE
Add control tasks

### DIFF
--- a/docs/tasks/control/task-date-input-type.md
+++ b/docs/tasks/control/task-date-input-type.md
@@ -1,0 +1,14 @@
+# Date Input Control
+
+## Description
+Support a date input that can restrict acceptable dates using minimum and maximum values. Administrators may also mark the question as mandatory.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Invalid date formats should be rejected.
+- Dates outside the allowed range must trigger validation errors.
+
+## Related Tasks
+- [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-direct-long-text-type.md
+++ b/docs/tasks/control/task-direct-long-text-type.md
@@ -1,0 +1,15 @@
+# Direct Long Text Input Control
+
+## Description
+Provide a textarea control for multi-line answers. Administrators may configure minimum and maximum length limits. The control must validate input length and show helpful messages when rules are violated.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Very long input might impact performance or exceed storage limits.
+- Browser autofill could insert text beyond allowed length.
+
+## Related Tasks
+- [task-direct-short-text-type.md](task-direct-short-text-type.md)
+- [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-direct-short-text-type.md
+++ b/docs/tasks/control/task-direct-short-text-type.md
@@ -1,0 +1,15 @@
+# Direct Short Text Input Control
+
+## Description
+Implement a single-line text input for short answers. Administrators can configure minimum and maximum length limits. The control should enforce these limits and display validation messages when the user input does not comply.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Input shorter or longer than allowed should trigger validation.
+- Trimming spaces may affect length validation.
+
+## Related Tasks
+- [task-direct-long-text-type.md](task-direct-long-text-type.md)
+- [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-file-upload-type.md
+++ b/docs/tasks/control/task-file-upload-type.md
@@ -1,0 +1,14 @@
+# File Upload Control
+
+## Description
+Provide an upload control where administrators can specify accepted file types, maximum size, and whether uploading is mandatory. Files exceeding limits or of unsupported types must be rejected with clear feedback.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Uploading files larger than allowed must be blocked gracefully.
+- Unsupported formats should display informative error messages.
+
+## Related Tasks
+- [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-multiple-choices-type.md
+++ b/docs/tasks/control/task-multiple-choices-type.md
@@ -1,0 +1,15 @@
+# Multiple Choices Control
+
+## Description
+Create a checklist allowing applicants to select multiple options. Administrators define the available choices, specify a required minimum selection count, and may allow an "other" text entry with length limits.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Users submitting fewer selections than required must see a validation error.
+- Manual "other" entry should respect configured length limits.
+
+## Related Tasks
+- [task-single-choice-type.md](task-single-choice-type.md)
+- [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-single-choice-type.md
+++ b/docs/tasks/control/task-single-choice-type.md
@@ -1,0 +1,15 @@
+# Single Choice Control
+
+## Description
+Implement a radio button list where only one option can be selected. Administrators decide whether a selection is mandatory and may permit an "other" input with length constraints.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Submitting without a selection when mandatory should show a validation error.
+- "Other" entry must enforce configured length limits.
+
+## Related Tasks
+- [task-multiple-choices-type.md](task-multiple-choices-type.md)
+- [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-video-link-type.md
+++ b/docs/tasks/control/task-video-link-type.md
@@ -1,0 +1,14 @@
+# Video Link Control
+
+## Description
+Implement a text input that accepts a URL to a video. Administrators can restrict allowed video formats and specify whether providing a link is mandatory. Invalid or unsupported links should be rejected with clear feedback.
+
+## Preconditions
+- Questionnaire administration interface exists.
+
+## Potential Errors or Edge Cases
+- Invalid URLs must trigger validation messages.
+- Links to unsupported formats should be rejected.
+
+## Related Tasks
+- [../task-applicant-interface.md](../task-applicant-interface.md)


### PR DESCRIPTION
## Summary
- add tasks for short text, long text, multiple choices, single choice, date input, file upload and video link controls

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684be2845d708333ad0cb98709cf60f9