### PR TITLE
Update control task docs with technical info

### DIFF
--- a/docs/tasks/control/task-control-common-interface.md
+++ b/docs/tasks/control/task-control-common-interface.md
@@ -1,0 +1,23 @@
+# Common Control Interface
+
+Every input control component should share a consistent API so that the questionnaire renderer can treat them uniformly. The interface below describes the minimal contract that each control must implement.
+
+## Interface Definition
+```ts
+export interface SurveyControl<T> extends ControlValueAccessor {
+  /** Unique identifier for the question */
+  id: string;
+  /** Display label shown to applicants */
+  label: string;
+  /** Whether a value is required */
+  required: boolean;
+  /** Optional placeholder text */
+  placeholder?: string;
+  /** Internal reactive value */
+  value: Signal<T>;
+  /** Validate the current value */
+  validate(): ValidationErrors | null;
+}
+```
+
+Controls may expose additional `@Input()` properties specific to their type (for example `minDate` for date inputs or `accept` for file uploads). All components must be standalone, use the `OnPush` change detection strategy and rely on signals for internal state.

--- a/docs/tasks/control/task-date-input-type.md
+++ b/docs/tasks/control/task-date-input-type.md
@@ -13,5 +13,12 @@ Support a date input that can restrict acceptable dates using minimum and maximu
 - Time zone differences might cause valid dates to appear invalid.
 - Configuration where the minimum date is after the maximum date should raise an admin warning.
 
+## Technical Details
+- Implement the control as a standalone component using `ControlValueAccessor` so it works with Angular reactive forms.
+- Expose `@Input()` properties for `minDate`, `maxDate`, `placeholder` and `required` flags.
+- Leverage an Angular Material date picker or an HTML5 `<input type="date">` element for the UI.
+- Validate the selected date against the configured range and emit meaningful errors via the form control.
+- Use the `OnPush` change detection strategy and signals to track the current value.
+
 ## Related Tasks
 - [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-direct-long-text-type.md
+++ b/docs/tasks/control/task-direct-long-text-type.md
@@ -12,6 +12,13 @@ Provide a textarea control for multi-line answers. Administrators may configure 
 - Browser autofill could insert text beyond allowed length.
 - Mobile browsers may auto-capitalize or insert line breaks unexpectedly.
 
+## Technical Details
+- Provide a standalone `<textarea>` component that implements `ControlValueAccessor`.
+- Inputs should include `minLength`, `maxLength`, `pattern`, `placeholder` and `required`.
+- Display a live remaining character count using a signal derived from the current value length.
+- Reject input containing HTML tags through a configurable regular expression.
+- Use `OnPush` change detection and keep internal state in signals.
+
 ## Related Tasks
 - [task-direct-short-text-type.md](task-direct-short-text-type.md)
 - [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-direct-short-text-type.md
+++ b/docs/tasks/control/task-direct-short-text-type.md
@@ -12,6 +12,13 @@ Implement a single-line text input for short answers. Administrators can configu
 - Trimming spaces may affect length validation.
 - Mobile keyboards may automatically capitalize or correct input.
 
+## Technical Details
+- Use a standalone `<input type="text">` component implementing `ControlValueAccessor`.
+- Support `minLength`, `maxLength`, `pattern`, `placeholder` and `required` as configurable inputs.
+- Optionally restrict input to numeric or custom patterns via `pattern`.
+- Expose the current value through a signal for easier integration with parent forms.
+- Apply `OnPush` change detection to minimize unnecessary re-rendering.
+
 ## Related Tasks
 - [task-direct-long-text-type.md](task-direct-long-text-type.md)
 - [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-file-upload-type.md
+++ b/docs/tasks/control/task-file-upload-type.md
@@ -12,5 +12,12 @@ Provide an upload control where administrators can specify accepted file types, 
 - Unsupported formats should display informative error messages.
 - Network interruptions while uploading should allow retrying without losing other form data.
 
+## Technical Details
+- Build a standalone component wrapping an `<input type="file">` element and implement `ControlValueAccessor`.
+- Accept configuration inputs for `accept`, `maxSize`, `required` and a custom upload service via injection token.
+- Validate file size and type before initiating the upload and surface errors through the form control state.
+- Show selected file name and progress using Angular signals; provide a remove option before submission.
+- Perform uploads through the provided service so storage implementations remain swappable.
+
 ## Related Tasks
 - [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-multiple-choices-type.md
+++ b/docs/tasks/control/task-multiple-choices-type.md
@@ -12,6 +12,13 @@ Create a checklist allowing applicants to select multiple options. Administrator
 - Manual "other" entry should respect configured length limits.
 - Large sets of options could make the form difficult to navigate on small screens.
 
+## Technical Details
+- Implement a standalone checkbox group component that provides `ControlValueAccessor` integration.
+- Accept an array of choice objects with `id`, `label` and optional `disabled` properties.
+- Support `minSelections`, `maxSelections`, `randomize`, `otherAllowed` and `otherLength` inputs for configuration.
+- Track selected options in a signal array and update the form control value accordingly.
+- Use `OnPush` change detection and emit validation errors when the selection count is outside the configured bounds.
+
 ## Related Tasks
 - [task-single-choice-type.md](task-single-choice-type.md)
 - [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-single-choice-type.md
+++ b/docs/tasks/control/task-single-choice-type.md
@@ -12,6 +12,13 @@ Implement a radio button list where only one option can be selected. Administrat
 - "Other" entry must enforce configured length limits.
 - Switching between an "other" entry and a predefined choice may leave stale values in the form state.
 
+## Technical Details
+- Build a standalone radio group component that uses `ControlValueAccessor` to communicate with parent forms.
+- Inputs should include the list of choices, orientation (`horizontal` or `vertical`), `required`, default value and optional "other" settings.
+- Manage the selected option with a signal and update the form control whenever it changes.
+- Validate that a choice is selected when required and ensure "other" input respects configured length constraints.
+- Utilize `OnPush` change detection for performance.
+
 ## Related Tasks
 - [task-multiple-choices-type.md](task-multiple-choices-type.md)
 - [../task-applicant-interface.md](../task-applicant-interface.md)

--- a/docs/tasks/control/task-video-link-type.md
+++ b/docs/tasks/control/task-video-link-type.md
@@ -12,5 +12,12 @@ Implement a text input that accepts a URL to a video. Administrators can restric
 - Links to unsupported formats should be rejected.
 - Shortened URLs may bypass validation and need to be expanded before checking.
 
+## Technical Details
+- Implement the control as a standalone component with a regular `<input type="url">` element.
+- Allow configuration of accepted providers through an injected validator service.
+- Provide `required`, `placeholder` and `preview` options via component inputs.
+- Fetch and display a thumbnail preview when the URL is valid using the preview service.
+- Implement `ControlValueAccessor` with `OnPush` change detection so it integrates seamlessly with reactive forms.
+
 ## Related Tasks
 - [../task-applicant-interface.md](../task-applicant-interface.md)


### PR DESCRIPTION
## Summary
- add implementation details to control docs
- introduce a common control interface document

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684be508cc748333a5a50640604ec0ab