### PR TITLE
Add QuestionnaireViewerComponent

### DIFF
--- a/src/app/applicant/questionnaire-viewer.component.html
+++ b/src/app/applicant/questionnaire-viewer.component.html
@@ -1,0 +1,42 @@
+<form (ngSubmit)="submit()" *ngIf="questionnaire as q">
+  @for (question of q.questions; track question.order) {
+    @if (isVisible(question.order)) {
+      <input-group [label]="question.label" [for]="'q'+question.order">
+        @switch (question.type) {
+          @case ('short_text') {
+            <input id="{{'q'+question.order}}" type="text" [required]="question.isRequired" [value]="answersSignal()[question.order] || ''" (input)="onAnswerChange(question.order, $any($event.target).value)" />
+          }
+          @case ('long_text') {
+            <textarea id="{{'q'+question.order}}" [required]="question.isRequired" (input)="onAnswerChange(question.order, $any($event.target).value)">{{answersSignal()[question.order] || ''}}</textarea>
+          }
+          @case ('single_choice') {
+            <div class="option" *ngFor="let opt of question.options">
+              <label>
+                <input type="radio" name="{{'q'+question.order}}" [value]="opt" [checked]="answersSignal()[question.order] === opt" (change)="onAnswerChange(question.order, opt)" [required]="question.isRequired" />
+                {{ opt }}
+              </label>
+            </div>
+          }
+          @case ('multiple_choice') {
+            <div class="option" *ngFor="let opt of question.options">
+              <label>
+                <input type="checkbox" [value]="opt" [checked]="(answersSignal()[question.order] || []).includes(opt)" (change)="onAnswerMultiChange(question.order, opt, $any($event.target).checked)" />
+                {{ opt }}
+              </label>
+            </div>
+          }
+          @case ('date') {
+            <input id="{{'q'+question.order}}" type="date" [required]="question.isRequired" [value]="answersSignal()[question.order] || ''" (change)="onAnswerChange(question.order, $any($event.target).value)" />
+          }
+          @case ('file_upload') {
+            <input id="{{'q'+question.order}}" type="file" [attr.accept]="question.allowedFileTypes" (change)="onAnswerChange(question.order, $any($event.target).files?.[0])" [required]="question.isRequired" />
+          }
+          @case ('video_link') {
+            <input id="{{'q'+question.order}}" type="text" placeholder="Video URL" [required]="question.isRequired" [value]="answersSignal()[question.order] || ''" (input)="onAnswerChange(question.order, $any($event.target).value)" />
+          }
+        }
+      </input-group>
+    }
+  }
+  <button type="submit">Submit</button>
+</form>

--- a/src/app/applicant/questionnaire-viewer.component.scss
+++ b/src/app/applicant/questionnaire-viewer.component.scss
@@ -1,0 +1,8 @@
+form {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+button {
+  margin-top: 1rem;
+}

--- a/src/app/applicant/questionnaire-viewer.component.ts
+++ b/src/app/applicant/questionnaire-viewer.component.ts
@@ -1,0 +1,91 @@
+import { Component, Input, signal, effect, OnInit, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Questionnaire, Question, Dependency } from '../models/questionnaire.model';
+import { InputGroupComponent } from '../kebormed-core/input-group.component';
+
+@Component({
+  selector: 'app-questionnaire-viewer',
+  standalone: true,
+  imports: [CommonModule, FormsModule, InputGroupComponent],
+  templateUrl: './questionnaire-viewer.component.html',
+  styleUrls: ['./questionnaire-viewer.component.scss']
+})
+export class QuestionnaireViewerComponent implements OnInit {
+  @Input() questionnaire!: Questionnaire;
+
+  private answersSignal = signal<Record<number, any>>({});
+  private visibilitySignal = signal<Record<number, boolean>>({});
+
+  ngOnInit(): void {
+    if (this.questionnaire) {
+      const initialVis: Record<number, boolean> = {};
+      for (const q of this.questionnaire.questions) {
+        initialVis[q.order] = q.initialVisibility === 'show';
+      }
+      this.visibilitySignal.set(initialVis);
+    }
+
+    effect(() => {
+      const answers = this.answersSignal();
+      if (!this.questionnaire) return;
+      const vis: Record<number, boolean> = { ...this.visibilitySignal() };
+      for (const q of this.questionnaire.questions) {
+        const deps = (this.questionnaire.dependencies || []).filter(d => d.targetQuestionOrder === q.order);
+        let visible = q.initialVisibility === 'show';
+        let hideMatched = false;
+        let showMatched = false;
+        let hasShowDep = false;
+        for (const dep of deps) {
+          const ans = answers[dep.sourceQuestionOrder];
+          const match = Array.isArray(ans)
+            ? ans.includes(dep.sourceAnswerOptionLabel)
+            : ans === dep.sourceAnswerOptionLabel;
+          if (dep.action === 'hide' && match) {
+            hideMatched = true;
+          }
+          if (dep.action === 'show') {
+            hasShowDep = true;
+            if (match) {
+              showMatched = true;
+            }
+          }
+        }
+        if (hideMatched) {
+          visible = false;
+        } else if (hasShowDep) {
+          visible = showMatched;
+        }
+        vis[q.order] = visible;
+      }
+      this.visibilitySignal.set(vis);
+    });
+  }
+
+  protected isVisible(order: number): boolean {
+    return this.visibilitySignal()[order];
+  }
+
+  protected onAnswerChange(order: number, value: any) {
+    this.answersSignal.update(a => ({ ...a, [order]: value }));
+  }
+
+  protected onAnswerMultiChange(order: number, label: string, checked: boolean) {
+    this.answersSignal.update(a => {
+      const existing = (a[order] as string[]) || [];
+      const next = checked ? [...existing, label] : existing.filter(l => l !== label);
+      return { ...a, [order]: next };
+    });
+  }
+
+  protected submit() {
+    const answers = this.answersSignal();
+    const visibleAnswers: Record<number, any> = {};
+    for (const q of this.questionnaire.questions) {
+      if (this.isVisible(q.order)) {
+        visibleAnswers[q.order] = answers[q.order];
+      }
+    }
+    console.log('Submitted answers', visibleAnswers);
+  }
+}

--- a/src/app/kebormed-core/input-group.component.ts
+++ b/src/app/kebormed-core/input-group.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'input-group',
+  standalone: true,
+  template: `
+    <div class="input-group">
+      <label *ngIf="label" [for]="for">{{ label }}</label>
+      <ng-content></ng-content>
+    </div>
+  `,
+  styles: [
+    `.input-group { display: flex; flex-direction: column; margin-bottom: 1rem; }`,
+    `label { font-weight: 600; margin-bottom: 0.25rem; }`
+  ]
+})
+export class InputGroupComponent {
+  @Input() label = '';
+  @Input() for = '';
+}

--- a/src/app/models/questionnaire.model.ts
+++ b/src/app/models/questionnaire.model.ts
@@ -1,0 +1,24 @@
+export interface Questionnaire {
+  programId: string;
+  version: number;
+  isPublished: boolean;
+  questions: Question[];
+  dependencies: Dependency[];
+}
+
+export interface Question {
+  order: number;
+  type: 'short_text' | 'long_text' | 'single_choice' | 'multiple_choice' | 'date' | 'file_upload' | 'video_link';
+  label: string;
+  initialVisibility: 'show' | 'hidden';
+  isRequired: boolean;
+  options?: string[]; // for choice questions
+  allowedFileTypes?: string; // for file_upload
+}
+
+export interface Dependency {
+  sourceQuestionOrder: number;
+  sourceAnswerOptionLabel: string;
+  targetQuestionOrder: number;
+  action: 'show' | 'hide';
+}


### PR DESCRIPTION
## Summary
- add models for questionnaire data
- stub InputGroup component in `@kebormed/core`
- implement standalone `QuestionnaireViewerComponent`
- include template and styles

## Testing
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_b_684c0ad31e38833383f9bf3625a3e53e