### PR TITLE
Fix admin templates and build warnings

### DIFF
--- a/src/app/admin/dependency-editor.component.html
+++ b/src/app/admin/dependency-editor.component.html
@@ -15,7 +15,7 @@
         </tr>
       </thead>
       <tbody>
-        @for (dep of depsSignal(); let i = index; track i) {
+        @for (dep of depsSignal(); let i = $index; track i) {
           <tr>
             <td>{{ getQuestionByOrder(dep.sourceQuestionOrder)?.label || '#' + dep.sourceQuestionOrder }}</td>
             <td>{{ dep.sourceAnswerOptionLabel }}</td>
@@ -31,16 +31,16 @@
     </table>
   }
 
-  @if (editingDep() as edep) {
+  @if (editingDep(); as edep) {
     <div class="edit-form">
-      <h4>@if(editingIndex() === -1){Add Dependency}else{Edit Dependency}</h4>
+      <h4>{{ editingIndex() === -1 ? 'Add Dependency' : 'Edit Dependency' }}</h4>
       <form (ngSubmit)="saveDep()">
         <input-group label="Source Question" for="srcq">
           <select
             id="srcq"
             [(ngModel)]="edep.sourceQuestionOrder"
             name="srcq"
-            (change)="onSourceQuestionChange(+($event.target as HTMLSelectElement).value)">
+            (change)="onSourceQuestionChange(+$any($event.target).value)">
             @for (q of questions; track q.order) {
               <option [value]="q.order">{{ q.order }}. {{ q.label }}</option>
             }
@@ -52,7 +52,7 @@
             id="srca"
             [(ngModel)]="edep.sourceAnswerOptionLabel"
             name="srca"
-            (change)="onSourceAnswerChange(($event.target as HTMLSelectElement).value)">
+            (change)="onSourceAnswerChange($any($event.target).value)">
             @for (opt of getQuestionByOrder(edep.sourceQuestionOrder)?.answerOptions || []; track opt.label) {
               <option [value]="opt.label">{{ opt.label }}</option>
             }
@@ -64,7 +64,7 @@
             id="tgtq"
             [(ngModel)]="edep.targetQuestionOrder"
             name="tgtq"
-            (change)="onTargetQuestionChange(+($event.target as HTMLSelectElement).value)">
+            (change)="onTargetQuestionChange(+$any($event.target).value)">
             @for (q of questions; track q.order) {
               <option [value]="q.order">{{ q.order }}. {{ q.label }}</option>
             }
@@ -76,7 +76,7 @@
             id="act"
             [(ngModel)]="edep.action"
             name="act"
-            (change)="onActionChange(($event.target as HTMLSelectElement).value)">
+            (change)="onActionChange($any($event.target).value)">
             <option value="show">Show</option>
             <option value="hide">Hide</option>
           </select>

--- a/src/app/admin/question-editor.component.html
+++ b/src/app/admin/question-editor.component.html
@@ -43,7 +43,7 @@
     <div class="answer-options">
       <label>Answer Options</label>
       <ul>
-        @for (opt of q.answerOptions || []; let i = index; track i) {
+        @for (opt of q.answerOptions || []; let i = $index; track i) {
           <li>
             <input [(ngModel)]="opt.label" name="opt{{i}}" />
             <button type="button" (click)="q.answerOptions!.splice(i,1)">Remove</button>

--- a/src/app/admin/questionnaire-editor.component.html
+++ b/src/app/admin/questionnaire-editor.component.html
@@ -7,7 +7,7 @@
   <div class="questions" *ngIf="questionsSignal().length">
     <h3>Questions</h3>
     <ol>
-      @for (q of questionsSignal(); let i = index; track q.order) {
+      @for (q of questionsSignal(); let i = $index; track q.order) {
         <li>
           <div class="question-header">
             <span>{{ q.order }}. {{ q.label || '(no label)' }} ({{ q.type }})</span>
@@ -21,9 +21,9 @@
     </ol>
   </div>
 
-  @if (editingQuestion() as eq) {
+  @if (editingQuestion(); as eq) {
     <div class="edit-form">
-      <h3>@if(editingIndex() === -1){Add Question}else{Edit Question}</h3>
+      <h3>{{ editingIndex() === -1 ? 'Add Question' : 'Edit Question' }}</h3>
       <form (ngSubmit)="saveQuestion()">
         <input-group label="Label" for="label">
           <input id="label" type="text" [(ngModel)]="eq.label" name="label" required />
@@ -65,7 +65,7 @@
           <div class="answer-options">
             <label>Answer Options</label>
             <ul>
-              @for (opt of eq.answerOptions || []; let oi = index; track oi) {
+              @for (opt of eq.answerOptions || []; let oi = $index; track oi) {
                 <li>
                   <input [(ngModel)]="opt.label" name="opt{{oi}}" />
                   <button type="button" (click)="eq.answerOptions!.splice(oi,1)">Remove</button>

--- a/src/app/applicant/question-renderer.component.html
+++ b/src/app/applicant/question-renderer.component.html
@@ -35,7 +35,7 @@
         <input
           type="text"
           [placeholder]="'Other...'"
-          [value]="value && !(question.answerOptions || []).some(o => o.label === value) ? value : ''"
+          [value]="manualEntryDisplay(value)"
           (input)="onTextInput($event)"
           [attr.minLength]="question.manualEntryMinLength"
           [attr.maxLength]="question.manualEntryMaxLength" />

--- a/src/app/applicant/question-renderer.component.ts
+++ b/src/app/applicant/question-renderer.component.ts
@@ -19,6 +19,14 @@ export class QuestionRendererComponent implements OnChanges {
   // used for multiple choice manual entry
   protected manualValue = signal('');
 
+  protected isPredefinedOption(val: string | undefined): boolean {
+    return !!val && (this.question.answerOptions?.some(o => o.label === val) ?? false);
+  }
+
+  protected manualEntryDisplay(val: string | undefined): string {
+    return val && !this.isPredefinedOption(val) ? val : '';
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if ('value' in changes && this.question?.type === 'multiple_choice' && this.question.allowManualEntry) {
       const val = changes['value'].currentValue as string[] | undefined;

--- a/src/app/applicant/questionnaire-viewer.component.ts
+++ b/src/app/applicant/questionnaire-viewer.component.ts
@@ -14,7 +14,7 @@ import { QuestionRendererComponent } from './question-renderer.component';
 export class QuestionnaireViewerComponent implements OnInit {
   @Input() questionnaire!: Questionnaire;
 
-  private answersSignal = signal<Record<number, any>>({});
+  protected answersSignal = signal<Record<number, any>>({});
   private visibilitySignal = signal<Record<number, boolean>>({});
 
   ngOnInit(): void {

--- a/src/app/kebormed-core/input-group.component.ts
+++ b/src/app/kebormed-core/input-group.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'input-group',
   standalone: true,
+  imports: [CommonModule],
   template: `
     <div class="input-group">
       <label *ngIf="label" [for]="for">{{ label }}</label>


### PR DESCRIPTION
## Summary
- import CommonModule for InputGroupComponent
- fix alias and loops in admin templates
- use `$any` helper for select change events
- provide helper for manual entry in QuestionRenderer
- expose answersSignal for the questionnaire viewer

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_684c1d2785b8833397456b05096b7ec8