### PR TITLE
Add acceptance criteria and definition of done docs

### DIFF
--- a/docs/tasks/task-accessibility-audit.md
+++ b/docs/tasks/task-accessibility-audit.md
@@ -1,0 +1,11 @@
+# Task: Accessibility audit
+
+## Acceptance Criteria
+- Evaluate all user-facing pages against WCAG 2.1 AA criteria
+- Identify and prioritize remediation items for color contrast, keyboard navigation and screen reader support
+- Document audit results and recommendations
+
+## Definition of Done
+- Accessibility issues tracked in the project backlog
+- Critical issues resolved before release
+- Audit report published for stakeholders

--- a/docs/tasks/task-add-authentication-authorization.md
+++ b/docs/tasks/task-add-authentication-authorization.md
@@ -1,0 +1,11 @@
+# Task: Add authentication and authorization
+
+## Acceptance Criteria
+- OAuth2/JWT based login implemented for administrators and applicants
+- Role-based access control restricts API and portal features accordingly
+- Refresh token or session expiration handled securely
+
+## Definition of Done
+- Authentication flow tested end-to-end
+- Unauthorized access attempts return 401 or 403
+- Security documentation updated

--- a/docs/tasks/task-admin-portal-dependency-editor.md
+++ b/docs/tasks/task-admin-portal-dependency-editor.md
@@ -1,0 +1,11 @@
+# Task: Admin Portal – Dependency Editor
+
+## Acceptance Criteria
+- Admins can define show/hide logic between questions via UI
+- Dependencies saved and retrieved through the Questionnaire API
+- Validation ensures circular dependencies are prevented
+
+## Definition of Done
+- Dependency rules evaluate correctly in the applicant portal
+- Feature tested with unit tests
+- Documentation updated with usage example

--- a/docs/tasks/task-admin-portal-questionnaire-builder.md
+++ b/docs/tasks/task-admin-portal-questionnaire-builder.md
@@ -1,0 +1,11 @@
+# Task: Build Admin Portal – Questionnaire Builder
+
+## Acceptance Criteria
+- Drag-and-drop interface allows arranging questions and input types
+- UI validates question configuration before saving
+- Changes persist to the Questionnaire API
+
+## Definition of Done
+- Feature covered by unit tests and component tests
+- Works across modern browsers
+- Screenshots included in documentation

--- a/docs/tasks/task-admin-portal-validation-editor.md
+++ b/docs/tasks/task-admin-portal-validation-editor.md
@@ -1,0 +1,11 @@
+# Task: Admin Portal – Validation Editor
+
+## Acceptance Criteria
+- Interface lets admins set required fields, length limits, date ranges and file constraints
+- Validation rules stored with each question definition
+- Error messages customizable via the admin UI
+
+## Definition of Done
+- Validation rules applied in the applicant portal
+- Unit tests cover rule persistence and execution
+- Admin guide updated with validation examples

--- a/docs/tasks/task-admin-portal-version-control-preview.md
+++ b/docs/tasks/task-admin-portal-version-control-preview.md
@@ -1,0 +1,11 @@
+# Task: Admin Portal – Version Control & Preview
+
+## Acceptance Criteria
+- Admins can save drafts and publish questionnaire versions
+- Preview mode shows applicant experience without affecting production data
+- History of published versions maintained in the database
+
+## Definition of Done
+- Version switching tested for backward compatibility
+- Preview shares the same validation logic as live forms
+- Release notes include versioning workflow

--- a/docs/tasks/task-api-documentation.md
+++ b/docs/tasks/task-api-documentation.md
@@ -1,0 +1,11 @@
+# Task: API documentation
+
+## Acceptance Criteria
+- OpenAPI specification published and accessible to developers
+- Endpoints include examples and authentication requirements
+- Documentation versioned alongside the API
+
+## Definition of Done
+- API docs deployed with CI/CD pipeline
+- Internal developers can test endpoints using the docs
+- Changelog reflects API doc updates

--- a/docs/tasks/task-applicant-portal-progress-tracking.md
+++ b/docs/tasks/task-applicant-portal-progress-tracking.md
@@ -1,0 +1,11 @@
+# Task: Applicant Portal – Progress Tracking & Save/Resume
+
+## Acceptance Criteria
+- Applicants can see completion status for each section
+- Draft progress saved securely and reloads on return
+- Resume links expire based on configurable timeframe
+
+## Definition of Done
+- Feature tested with e2e tests across browsers
+- Progress updates persisted via Application API
+- Help documentation updated with resume instructions

--- a/docs/tasks/task-build-applicant-portal-dynamic-form.md
+++ b/docs/tasks/task-build-applicant-portal-dynamic-form.md
@@ -1,0 +1,11 @@
+# Task: Build Applicant Portal – Dynamic Form
+
+## Acceptance Criteria
+- Questionnaire renders with dependencies and real-time validation
+- Supports rich media inputs including file uploads and text areas
+- UI responsive across desktop and mobile
+
+## Definition of Done
+- Dynamic form component has unit tests and e2e coverage
+- Works with the latest published questionnaire version
+- User feedback collected in UX review

--- a/docs/tasks/task-ci-cd-pipeline.md
+++ b/docs/tasks/task-ci-cd-pipeline.md
@@ -1,0 +1,11 @@
+# Task: Set up CI/CD pipeline
+
+## Acceptance Criteria
+- Automated build and test steps run for frontend and backend projects
+- Deployment to staging triggered on successful builds
+- Pipeline configuration stored as code and version controlled
+
+## Definition of Done
+- CI/CD pipeline passes on initial deployment
+- Rollback procedure documented
+- Developers notified on pipeline status

--- a/docs/tasks/task-file-upload-handling.md
+++ b/docs/tasks/task-file-upload-handling.md
@@ -1,0 +1,11 @@
+# Task: File Upload Handling
+
+## Acceptance Criteria
+- Backend accepts file uploads with size and type validation
+- Files stored in an S3-compatible service using unique identifiers
+- Errors for invalid files clearly communicated to the frontend
+
+## Definition of Done
+- Upload endpoints covered by unit and integration tests
+- Uploaded files retrievable via secure URLs
+- Infrastructure configuration documented

--- a/docs/tasks/task-implement-application-api.md
+++ b/docs/tasks/task-implement-application-api.md
@@ -1,0 +1,11 @@
+# Task: Implement Application API
+
+## Acceptance Criteria
+- Endpoints allow creating, saving and submitting applications
+- Data model aligns with the Application entity in the SRS
+- Input validation handles required fields and file metadata
+
+## Definition of Done
+- API endpoints covered by unit tests
+- Persisted applications retrievable via the API
+- OpenAPI specification updated with application operations

--- a/docs/tasks/task-implement-questionnaire-api.md
+++ b/docs/tasks/task-implement-questionnaire-api.md
@@ -1,0 +1,11 @@
+# Task: Implement Questionnaire API
+
+## Acceptance Criteria
+- CRUD endpoints for programs and questionnaires are available
+- API supports versioning and publishing workflow as described in the SRS
+- Validation errors return meaningful HTTP status codes
+
+## Definition of Done
+- Endpoints covered by unit tests
+- API documented in OpenAPI format
+- All tests pass and endpoints accessible in local environment

--- a/docs/tasks/task-setup-database-schema.md
+++ b/docs/tasks/task-setup-database-schema.md
@@ -1,0 +1,11 @@
+# Task: Set up database schema
+
+## Acceptance Criteria
+- PostgreSQL tables for programs, questionnaires, questions, answer options, dependencies, applications and answers match the SRS ER diagram
+- All foreign key relations enforce referential integrity
+- Schema changes managed via migration scripts
+
+## Definition of Done
+- Migrations run successfully on a clean database
+- Tables and relations verified via automated tests
+- Documentation updated with schema overview

--- a/docs/tasks/task-unit-and-e2e-tests-frontend.md
+++ b/docs/tasks/task-unit-and-e2e-tests-frontend.md
@@ -1,0 +1,11 @@
+# Task: Unit and E2E tests for frontend
+
+## Acceptance Criteria
+- Component tests verify rendering and interactions in both portals
+- End-to-end tests cover common user flows and error states
+- Tests run headless in CI for Chrome and Firefox
+
+## Definition of Done
+- Frontend test coverage exceeds 80%
+- CI passes on all supported browsers
+- Test plan documented for future features

--- a/docs/tasks/task-unit-tests-backend-services.md
+++ b/docs/tasks/task-unit-tests-backend-services.md
@@ -1,0 +1,11 @@
+# Task: Unit tests for backend services
+
+## Acceptance Criteria
+- Tests cover API endpoints, dependency evaluation and validation logic
+- Test data includes edge cases defined in the SRS
+- Continuous integration runs tests on each commit
+
+## Definition of Done
+- Coverage report shows at least 80% for backend modules
+- Failed tests block merges in CI
+- Test documentation includes setup instructions


### PR DESCRIPTION
## Summary
- outline tasks from `task-sephora-accelerate.md`
- add acceptance criteria and definition of done for each task

## Testing
- `npm test -- --watch=false` *(fails: Cannot find module './admin/question-editor.component')*

------
https://chatgpt.com/codex/tasks/task_b_684c824766f0833394dd7a8f5af2f2fb