### PR TITLE
Add detailed frontend task breakdown

### DIFF
--- a/docs/task/fe-task-applicant-questionnaire.md
+++ b/docs/task/fe-task-applicant-questionnaire.md
@@ -1,0 +1,30 @@
+# Frontend Task Breakdown: Applicant Questionnaire
+
+These tasks cover rendering questionnaires for applicants. They combine the data model from the [SRS](../srs.md) with the high level requirement in [task-frontend.md](./task-frontend.md).
+
+## Goals
+- Fetch questionnaires via REST and present them to applicants.
+- Validate answers and support file upload and video link input.
+- Submit responses back to the backend API.
+
+## Tasks
+1. **Data Retrieval**
+   - Use a service with `resource()` to call `GET /questionnaires/{id}`.
+   - Render loading and error states with `@defer` blocks.
+2. **Dynamic Form Rendering**
+   - For each question, instantiate a standalone component matching its type.
+   - Use signals to track answers and computed validation status.
+   - Support file uploads and manual answer options where allowed.
+3. **Validation & Submission**
+   - Enforce mandatory questions and constraints from the SRS.
+   - Display inline error messages when validation fails.
+   - Post results to `/responses` using an injectable service.
+4. **Testing**
+   - Unit test question components, validation logic, and successful submission.
+   - Consider Playwright E2E tests for basic completion flow.
+
+## Best Practices
+- Use `NgOptimizedImage` for any images and lazy load heavy components.
+- Ensure forms are keyboard accessible and use ARIA attributes.
+- Keep the templates simple with `@if`, `@defer`, and `@switch` only.
+

--- a/docs/task/fe-task-conditional-logic.md
+++ b/docs/task/fe-task-conditional-logic.md
@@ -1,0 +1,27 @@
+# Frontend Task Breakdown: Conditional Logic UI
+
+Build the interface for defining dependencies between questions. This feature ensures questions are shown or hidden based on previous answers, as specified in the [SRS](../srs.md).
+
+## Goals
+- Allow administrators to create show/hide rules between questions.
+- Apply these rules in the applicant portal when rendering questionnaires.
+
+## Tasks
+1. **Rule Model**
+   - Define a TypeScript model describing a dependency (source question, value, target question, action).
+   - Store rules in a signal array within the editor component.
+2. **Rule Editor Component**
+   - Provide a standalone component to add and remove rules.
+   - Use dropdowns for selecting questions and answers; follow signals-first approach.
+   - Expose the rule list via `model()` for integration with the questionnaire editor.
+3. **Preview & Validation**
+   - Include a simple preview of rule evaluation for current questionnaire data.
+   - Validate that referenced questions exist and warn about circular dependencies.
+4. **Testing**
+   - Add Jest tests for rule creation and preview logic.
+
+## Best Practices
+- Use `@if` and `@switch` to display rule fields without inline expressions.
+- Keep all new files in kebab-case folders with component, style, and tests colocated.
+- Document public APIs for easier use by other agents.
+

--- a/docs/task/fe-task-questionnaire-editor.md
+++ b/docs/task/fe-task-questionnaire-editor.md
@@ -1,0 +1,33 @@
+# Frontend Task Breakdown: Questionnaire Editor
+
+Detailed tasks for implementing the administration interface based on the [SRS](../srs.md) requirements.
+
+## Goals
+- Allow administrators to create, edit, and delete questionnaires and questions.
+- Support all input types described in the SRS.
+- Send data changes to the REST API.
+
+## Tasks
+1. **Questionnaire List Page**
+   - Display existing questionnaires with options to create, edit, or delete.
+   - Retrieve data using a service wrapped in `resource()` and show loading states with `@defer`.
+2. **Questionnaire Form**
+   - Build a standalone component with signals for form state.
+   - Provide fields for title and description.
+   - Use typed models and reactive forms.
+3. **Question Management**
+   - Allow adding multiple questions, each configured with type, required flag, and constraints.
+   - Componentize each question input type (short text, long text, multiple choice, etc.).
+   - Use `model()` to expose state and `inject()` for dependencies.
+4. **Persistence**
+   - Call backend endpoints (`/questionnaires` and `/questionnaires/{id}`) on save/update.
+   - Handle success and error notifications via signals.
+5. **Testing**
+   - Write Jest unit tests for form logic and API interactions.
+   - Verify computed signals and error handling.
+
+## Best Practices
+- Keep templates free of inline logic; rely on `@if` and `@switch` for control flow.
+- Store SCSS per component and follow the naming convention from [AGENTS.md](../../AGENTS.md).
+- Ensure ARIA labels and keyboard navigation for all form controls.
+

--- a/docs/task/fe-task-responsive-accessible.md
+++ b/docs/task/fe-task-responsive-accessible.md
@@ -1,0 +1,25 @@
+# Frontend Task Breakdown: Responsive & Accessible Design
+
+Guidelines for ensuring the portals work on various devices and meet basic accessibility standards as stated in the [SRS](../srs.md).
+
+## Goals
+- Provide a responsive layout for desktop and mobile screens.
+- Pass accessibility checks with ARIA labels and keyboard navigation.
+
+## Tasks
+1. **Responsive Layout**
+   - Use CSS grid/flex and media queries or Tailwind utility classes.
+   - Verify components scale from 1440px down to mobile widths.
+2. **Accessibility Features**
+   - Add ARIA roles and labels to form controls and buttons.
+   - Ensure all interactive elements are reachable via keyboard.
+   - Provide focus styles and skip links where appropriate.
+3. **Testing**
+   - Integrate axe-core or a similar tool into Jest or Playwright tests.
+   - Document any issues and update styles accordingly.
+
+## Best Practices
+- Adhere to the code quality checklist in [AGENTS.md](../../AGENTS.md).
+- Keep SCSS localized to components and avoid global overrides.
+- Use semantic HTML elements whenever possible.
+

--- a/docs/task/fe-task-setup-angular.md
+++ b/docs/task/fe-task-setup-angular.md
@@ -1,0 +1,33 @@
+# Frontend Task Breakdown: Setup Angular Projects
+
+This guide expands the high level **Setup Angular Projects** item from [task-frontend.md](./task-frontend.md). It aligns with the [SRS](../srs.md) and [Architecture](../architecture.md).
+
+## Goals
+- Bootstrap two Angular 20 applications: **Admin Portal** and **Applicant Portal**.
+- Ensure the workspace uses standalone components and a signals-first structure.
+- Provide linting/formatting via ESLint and Prettier.
+
+## Tasks
+1. **Initialize Angular Workspace**
+   - Use `ng new` with Angular 20.
+   - Enable standalone APIs (`--standalone` flag) and SCSS styling.
+   - Configure default prefix and paths.
+2. **Create Portals**
+   - Generate separate projects for `admin` and `applicant` using `ng generate application`.
+   - Confirm both compile using `ng serve` with placeholder routes.
+3. **Shared Library**
+   - Create a library for shared primitives under `@kebormed/core`.
+   - Use kebab-case folders and place component, template, style, and tests together.
+4. **Tooling Setup**
+   - Add ESLint configuration and run `ng lint`.
+   - Add Prettier configuration for consistent formatting.
+   - Add simple Jest setup (replace Karma) following repository guidelines.
+5. **CI Integration**
+   - Ensure scripts `npm run build` and `npm test` work without prompts.
+   - Prepare GitHub Actions to install dependencies, lint, build, and test.
+
+## Best Practices
+- Follow the folder and naming conventions from [AGENTS.md](../../AGENTS.md).
+- Keep all new components standalone and signals-based.
+- Commit with conventional messages and keep tasks small.
+


### PR DESCRIPTION
## Summary
- add granular frontend tasks for setup, questionnaire editor, conditional logic, applicant flow, and responsive design

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_684fcc8c23e48333becd4d107c3f6e03