### PR TITLE
Add input control task docs

### DIFF
--- a/docs/task/controls/task-date-input.md
+++ b/docs/task/controls/task-date-input.md
@@ -1,0 +1,19 @@
+# Frontend Task: Date Input Component
+
+Develop the date picker control according to the [SRS](../../srs.md) and [User Needs](../../user-needs.md).
+
+## Goals
+- Provide a date input respecting `required`, minimum, and maximum date constraints.
+- Expose the selected date via `model()` using signals.
+
+## Tasks
+1. Generate `date-input` component in its own folder.
+2. Accept `required`, `minDate`, and `maxDate` inputs.
+3. Use signals to track the selected date.
+4. Validate the date against boundaries and show errors with `@if`.
+5. Write Jest tests for validation and signal output.
+
+## Best Practices
+- Keep template control flow simple.
+- Store SCSS and tests with the component.
+- Follow conventions in [AGENTS.md](../../../AGENTS.md).

--- a/docs/task/controls/task-file-upload.md
+++ b/docs/task/controls/task-file-upload.md
@@ -1,0 +1,20 @@
+# Frontend Task: File Upload Component
+
+Build the file upload control as outlined in the [SRS](../../srs.md) and [User Needs](../../user-needs.md).
+
+## Goals
+- Accept files while enforcing type and size restrictions.
+- Present a list of selected files.
+- Provide state through `model()` using signals.
+
+## Tasks
+1. Generate `file-upload` component in its own folder.
+2. Configure accepted file types, maximum size, and `required` flag.
+3. Use signals to store selected files and validation results.
+4. Display errors and file list using `@if` blocks only.
+5. Add Jest tests covering file restrictions and emitted state.
+
+## Best Practices
+- Keep template logic minimal.
+- Include SCSS and tests alongside the component files.
+- Adhere to [AGENTS.md](../../../AGENTS.md) guidelines.

--- a/docs/task/controls/task-long-text.md
+++ b/docs/task/controls/task-long-text.md
@@ -1,0 +1,20 @@
+# Frontend Task: Long Text Component
+
+Create the multi-line text area component per the [SRS](../../srs.md) and [User Needs](../../user-needs.md).
+
+## Goals
+- Multi-line textarea with the same length validations as the short text control.
+- Expose typed signals via `model()`.
+- Show errors using `@if`.
+
+## Tasks
+1. Generate `long-text` component in its own folder.
+2. Support `required`, `minLength`, and `maxLength` inputs.
+3. Provide a signal for value updates through `model()`.
+4. Render validation messages when limits are exceeded.
+5. Add a Jest test for validation and emitted value.
+
+## Best Practices
+- Keep templates simple and free of logic.
+- Include SCSS and tests alongside the component.
+- Follow standards defined in [AGENTS.md](../../../AGENTS.md).

--- a/docs/task/controls/task-multiple-choice.md
+++ b/docs/task/controls/task-multiple-choice.md
@@ -1,0 +1,22 @@
+# Frontend Task: Multiple Choice Component
+
+Implement the checkbox list control as described in the [SRS](../../srs.md) and [User Needs](../../user-needs.md).
+
+## Goals
+- Allow multiple selections from predefined options.
+- Support optional manual answer entry with its own length validation.
+- Enforce a minimum number of selections when configured.
+- Expose state via `model()` using signals.
+
+## Tasks
+1. Generate `multiple-choice` component in a dedicated folder.
+2. Accept inputs for the list of options, `required`, `minSelections`, and manual entry settings.
+3. Track selected options and manual text value through signals.
+4. Validate selection count and manual entry length, showing errors with `@if`.
+5. Emit a combined value model via `model()`.
+6. Add Jest tests covering selection logic and validation rules.
+
+## Best Practices
+- Keep the template readable and free of complex logic.
+- Place component, template, styles, and tests together.
+- Follow the guidelines in [AGENTS.md](../../../AGENTS.md).

--- a/docs/task/controls/task-short-text.md
+++ b/docs/task/controls/task-short-text.md
@@ -1,0 +1,20 @@
+# Frontend Task: Short Text Component
+
+Implement the standalone short text input control referenced in the [SRS](../../srs.md) and [User Needs](../../user-needs.md).
+
+## Goals
+- Single-line text input with minimum and maximum length validation.
+- Expose value and validity via `model()` using signals.
+- Display validation errors with `@if` blocks only.
+
+## Tasks
+1. Generate `short-text` component in a kebab-case folder.
+2. Accept inputs for `required`, `minLength`, and `maxLength`.
+3. Emit updates through a signal returned from `model()`.
+4. Show inline error messages when constraints are violated.
+5. Provide a Jest test verifying validation and signal output.
+
+## Best Practices
+- Keep templates free of complex logic.
+- Store component file, HTML, SCSS, and tests together.
+- Follow the coding standards from [AGENTS.md](../../../AGENTS.md).

--- a/docs/task/controls/task-single-choice.md
+++ b/docs/task/controls/task-single-choice.md
@@ -1,0 +1,20 @@
+# Frontend Task: Single Choice Component
+
+Create the radio button list control based on the [SRS](../../srs.md) and [User Needs](../../user-needs.md).
+
+## Goals
+- Present predefined options where only one may be selected.
+- Optionally allow manual answer entry with length validation.
+- Emit selected value via `model()` using signals.
+
+## Tasks
+1. Generate `single-choice` component in its own folder.
+2. Accept option list, `required` flag, and manual entry settings as inputs.
+3. Track the chosen option and manual text through signals.
+4. Validate the manual entry length and enforce selection when required, showing errors with `@if`.
+5. Provide Jest tests verifying selection logic and validations.
+
+## Best Practices
+- Avoid inline logic in templates; use `@if` and `@switch` for control flow.
+- Group component, template, styles, and tests together.
+- Follow [AGENTS.md](../../../AGENTS.md) standards.

--- a/docs/task/controls/task-unit-tests.md
+++ b/docs/task/controls/task-unit-tests.md
@@ -1,0 +1,16 @@
+# Frontend Task: Component Unit Tests
+
+Write Jest tests for each input control component defined in this folder.
+
+## Goals
+- Cover validation rules and signal outputs for short text, long text, multiple choice, single choice, date input, file upload, and video link components.
+
+## Tasks
+1. Set up Jest configuration if not already available in the project.
+2. For each component, test valid and invalid input scenarios.
+3. Verify that `model()` signals emit the correct values and validity state.
+4. Ensure edge cases such as minimum selections and file type restrictions are tested.
+
+## Best Practices
+- Keep tests in the same folder as the component they cover.
+- Follow naming conventions from [AGENTS.md](../../../AGENTS.md).

--- a/docs/task/controls/task-video-link.md
+++ b/docs/task/controls/task-video-link.md
@@ -1,0 +1,20 @@
+# Frontend Task: Video Link Component
+
+Create the video URL input component as specified in the [SRS](../../srs.md) and [User Needs](../../user-needs.md).
+
+## Goals
+- Provide a text field for entering a video link.
+- Validate that the input is a well-formed URL.
+- Expose the value and validity via `model()` using signals.
+
+## Tasks
+1. Generate `video-link` component in a dedicated folder.
+2. Accept `required` flag and perform basic URL validation.
+3. Use signals to store the entered URL and validation state.
+4. Display validation errors with `@if` blocks.
+5. Supply a Jest test for URL validation and signal output.
+
+## Best Practices
+- Keep the component folder self-contained.
+- Avoid complex template logic; rely on control flow blocks.
+- Follow [AGENTS.md](../../../AGENTS.md) coding standards.


### PR DESCRIPTION
## Summary
- document tasks for each input control component
- include unit test guidance for the components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684fd1b4d4e48333b2f66711c607a6fe