### PR TITLE
Add multiple choice control

### DIFF
--- a/src/app/shared/controls/multiple-choice/multiple-choice.html
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.html
@@ -1,0 +1,23 @@
+<div class="options">
+  <label *ngFor="let option of options">
+    <input
+      type="checkbox"
+      [checked]="selectedOptions().includes(option)"
+      (change)="toggle(option, $event.target.checked)" />
+    {{ option }}
+  </label>
+</div>
+@if (selectionError()) {
+  <p class="error">{{ selectionError() }}</p>
+}
+@if (allowManualEntry) {
+  <label class="manual">
+    <input
+      type="text"
+      [value]="manualValue()"
+      (input)="updateManual($event.target.value)" />
+  </label>
+  @if (manualError()) {
+    <p class="error">{{ manualError() }}</p>
+  }
+}

--- a/src/app/shared/controls/multiple-choice/multiple-choice.scss
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.scss
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.error {
+  color: red;
+  font-size: 0.875rem;
+}

--- a/src/app/shared/controls/multiple-choice/multiple-choice.spec.ts
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MultipleChoice } from './multiple-choice';
+
+describe('MultipleChoice', () => {
+  let fixture: ComponentFixture<MultipleChoice>;
+  let component: MultipleChoice;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MultipleChoice]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MultipleChoice);
+    component = fixture.componentInstance;
+    component.options = ['A', 'B', 'C'];
+    fixture.detectChanges();
+  });
+
+  it('should emit selected values', () => {
+    component.toggle('A', true);
+    fixture.detectChanges();
+    expect(component.value().selections).toEqual(['A']);
+  });
+
+  it('should validate min selections', () => {
+    component.required = true;
+    component.minSelections = 2;
+    component.toggle('A', true);
+    fixture.detectChanges();
+    expect((component as any).selectionError()).toContain('at least');
+  });
+
+  it('should validate manual entry length', () => {
+    component.allowManualEntry = true;
+    component.manualMinLength = 3;
+    component.updateManual('ab');
+    fixture.detectChanges();
+    expect((component as any).manualError()).toContain('Minimum length');
+  });
+});

--- a/src/app/shared/controls/multiple-choice/multiple-choice.ts
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.ts
@@ -1,0 +1,78 @@
+import { Component, Input, computed, effect, model, signal } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+interface MultipleChoiceValue {
+  selections: string[];
+  manual: string;
+}
+
+@Component({
+  selector: 'app-multiple-choice',
+  standalone: true,
+  imports: [NgFor, NgIf, FormsModule],
+  templateUrl: './multiple-choice.html',
+  styleUrl: './multiple-choice.scss'
+})
+export class MultipleChoice {
+  @Input() options: string[] = [];
+  @Input() required = false;
+  @Input() minSelections = 0;
+  @Input() allowManualEntry = false;
+  @Input() manualMinLength = 0;
+  @Input() manualMaxLength = Infinity;
+
+  protected selectedOptions = signal<string[]>([]);
+  protected manualValue = signal('');
+
+  value = model<MultipleChoiceValue>({ selections: [], manual: '' });
+
+  protected selectionError = computed(() => {
+    const count = this.selectedOptions().length;
+    if (this.required && count === 0) {
+      return 'Selection required';
+    }
+    if (this.minSelections && count < this.minSelections) {
+      return `Select at least ${this.minSelections}`;
+    }
+    return '';
+  });
+
+  protected manualError = computed(() => {
+    if (!this.allowManualEntry) return '';
+    const val = this.manualValue();
+    if (!val) return '';
+    if (this.manualMinLength && val.length < this.manualMinLength) {
+      return `Minimum length is ${this.manualMinLength}`;
+    }
+    if (this.manualMaxLength !== Infinity && val.length > this.manualMaxLength) {
+      return `Maximum length is ${this.manualMaxLength}`;
+    }
+    return '';
+  });
+
+  constructor() {
+    effect(() => {
+      this.value.set({ selections: this.selectedOptions(), manual: this.manualValue() });
+    });
+  }
+
+  toggle(option: string, checked: boolean) {
+    const values = this.selectedOptions().slice();
+    if (checked) {
+      if (!values.includes(option)) {
+        values.push(option);
+      }
+    } else {
+      const idx = values.indexOf(option);
+      if (idx !== -1) {
+        values.splice(idx, 1);
+      }
+    }
+    this.selectedOptions.set(values);
+  }
+
+  updateManual(val: string) {
+    this.manualValue.set(val);
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone multiple choice component with signals
- include template and styling
- provide Karma unit tests following project style

## Testing
- `npm test -- --no-watch --browsers ChromeHeadless --code-coverage=false` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_b_684fd41bceac8333b168ec7f30a1fa76