### PR TITLE
Add MultipleChoice usage example

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,7 @@
+<h1>Hello, survey</h1>
+<app-multiple-choice
+  [options]="['Red', 'Blue', 'Green']"
+  [required]="true"
+  [allowManualEntry]="true"
+  [manualMinLength]="3"/>
 <router-outlet/>


### PR DESCRIPTION
## Summary
- demonstrate `MultipleChoice` control usage in the root `App` template

## Testing
- `CI=true npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_684fd71d45bc8333a07bc448dcf71287