### PR TITLE
Add single-choice radio control

### DIFF
--- a/src/app/shared/controls/single-choice/single-choice.html
+++ b/src/app/shared/controls/single-choice/single-choice.html
@@ -1,0 +1,35 @@
+<div
+  class="options"
+  role="radiogroup"
+  [attr.aria-label]="name"
+  [attr.aria-describedby]="selectionError() ? selectionErrorId : null"
+>
+  @for (option of options; track option) {
+    <label>
+      <input
+        type="radio"
+        name="{{ name }}"
+        [checked]="isSelected(option)"
+        (change)="onSelect($event, option)"
+      />
+      {{ option }}
+    </label>
+  }
+</div>
+@if (selectionError()) {
+  <p class="error" [id]="selectionErrorId">{{ selectionError() }}</p>
+}
+@if (allowManualEntry) {
+  <label class="manual">
+    <input
+      type="text"
+      [value]="manualValue()"
+      (input)="onManual($event)"
+      [attr.aria-invalid]="manualError() ? true : null"
+      [attr.aria-describedby]="manualError() ? manualErrorId : null"
+    />
+  </label>
+  @if (manualError()) {
+    <p class="error" [id]="manualErrorId">{{ manualError() }}</p>
+  }
+}

--- a/src/app/shared/controls/single-choice/single-choice.scss
+++ b/src/app/shared/controls/single-choice/single-choice.scss
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.error {
+  color: red;
+  font-size: 0.875rem;
+}

--- a/src/app/shared/controls/single-choice/single-choice.spec.ts
+++ b/src/app/shared/controls/single-choice/single-choice.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SingleChoice } from './single-choice';
+
+describe('SingleChoice', () => {
+  let fixture: ComponentFixture<SingleChoice>;
+  let component: SingleChoice;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SingleChoice]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SingleChoice);
+    component = fixture.componentInstance;
+    component.options = ['A', 'B', 'C'];
+    fixture.detectChanges();
+  });
+
+  it('should emit selected value', () => {
+    component.select('B');
+    fixture.detectChanges();
+    expect(component.value().selection).toBe('B');
+  });
+
+  it('should require selection when configured', () => {
+    component.required = true;
+    fixture.detectChanges();
+    expect((component as any).selectionError()).toContain('required');
+  });
+
+  it('should validate manual entry length', () => {
+    component.allowManualEntry = true;
+    component.manualMinLength = 3;
+    component.updateManual('ab');
+    fixture.detectChanges();
+    expect((component as any).manualError()).toContain('Minimum length');
+  });
+});

--- a/src/app/shared/controls/single-choice/single-choice.ts
+++ b/src/app/shared/controls/single-choice/single-choice.ts
@@ -1,0 +1,78 @@
+import { Component, Input, computed, effect, model, signal } from '@angular/core';
+
+interface SingleChoiceValue {
+  selection: string;
+  manual: string;
+}
+
+@Component({
+  selector: 'app-single-choice',
+  standalone: true,
+  imports: [],
+  templateUrl: './single-choice.html',
+  styleUrl: './single-choice.scss'
+})
+export class SingleChoice {
+  @Input() name = '';
+  @Input() options: string[] = [];
+  @Input() required = false;
+  @Input() allowManualEntry = false;
+  @Input() manualMinLength = 0;
+  @Input() manualMaxLength = Infinity;
+
+  protected readonly selected = signal('');
+  protected readonly manualValue = signal('');
+
+  readonly value = model<SingleChoiceValue>({ selection: '', manual: '' });
+
+  readonly selectionErrorId = `sc-selection-error-${crypto.randomUUID()}`;
+  readonly manualErrorId = `sc-manual-error-${crypto.randomUUID()}`;
+
+  protected readonly selectionError = computed(() => {
+    if (this.required && !this.selected()) {
+      return 'Selection required';
+    }
+    return '';
+  });
+
+  protected readonly manualError = computed(() => {
+    if (!this.allowManualEntry) return '';
+    const val = this.manualValue();
+    if (!val) return '';
+    if (this.manualMinLength && val.length < this.manualMinLength) {
+      return `Minimum length is ${this.manualMinLength}`;
+    }
+    if (this.manualMaxLength !== Infinity && val.length > this.manualMaxLength) {
+      return `Maximum length is ${this.manualMaxLength}`;
+    }
+    return '';
+  });
+
+  constructor() {
+    effect(() => {
+      this.value.set({ selection: this.selected(), manual: this.manualValue() });
+    });
+  }
+
+  isSelected(option: string): boolean {
+    return this.selected() === option;
+  }
+
+  onSelect(event: Event, option: string): void {
+    const checked = (event.target as HTMLInputElement | null)?.checked ?? false;
+    if (checked) this.select(option);
+  }
+
+  onManual(event: Event): void {
+    const value = (event.target as HTMLInputElement | null)?.value ?? '';
+    this.updateManual(value);
+  }
+
+  select(option: string): void {
+    this.selected.set(option);
+  }
+
+  updateManual(val: string): void {
+    this.manualValue.set(val);
+  }
+}


### PR DESCRIPTION
## Summary
- implement single-choice control with signals and validation
- add template and styles
- provide Karma unit tests

## Testing
- `npm test --silent -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_684fdfb0ba4c8333856f9eed718694b8