### PR TITLE
Add single-choice usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ To run tests:
 npm test
 ```
 
+## Example Usage
+
+The `SingleChoice` component can be used to present radio options with optional manual entry:
+
+```html
+<app-single-choice
+  name="favoriteColor"
+  [options]="['Red', 'Blue', 'Green']"
+  [required]="true"
+  [allowManualEntry]="true"
+  [manualMinLength]="2"
+></app-single-choice>
+```
+
 ## License
 
 This project is currently released under a placeholder license.

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -4,4 +4,11 @@
   [required]="true"
   [allowManualEntry]="true"
   [manualMinLength]="3"/>
+<app-single-choice
+  name="favoriteColor"
+  [options]="['Red', 'Blue', 'Green']"
+  [required]="true"
+  [allowManualEntry]="true"
+  [manualMinLength]="2"
+/>
 <router-outlet/>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import {MultipleChoice} from './shared/controls/multiple-choice/multiple-choice';
+import { MultipleChoice } from './shared/controls/multiple-choice/multiple-choice';
+import { SingleChoice } from './shared/controls/single-choice/single-choice';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, MultipleChoice],
+  imports: [RouterOutlet, MultipleChoice, SingleChoice],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })


### PR DESCRIPTION
## Summary
- show example usage of `SingleChoice` component in README
- render `SingleChoice` in `app.html`
- import the component in `App`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_684fe1ae4300833395558ae9736e62de