### PR TITLE
Fix single choice manual entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
-- Placeholder for upcoming changes.
+- Fixed manual entry not deselecting predefined option in `SingleChoice` control.
 
 ## [1.1.0] - 2025-06-14
 ### Added

--- a/src/app/shared/controls/single-choice/single-choice.spec.ts
+++ b/src/app/shared/controls/single-choice/single-choice.spec.ts
@@ -35,4 +35,22 @@ describe('SingleChoice', () => {
     fixture.detectChanges();
     expect((component as any).manualError()).toContain('Minimum length');
   });
+
+  it('should deselect option when manual value entered', () => {
+    component.allowManualEntry = true;
+    component.select('A');
+    component.updateManual('custom');
+    fixture.detectChanges();
+    expect(component.value().selection).toBe('');
+    expect(component.value().manual).toBe('custom');
+  });
+
+  it('should clear manual value when option selected', () => {
+    component.allowManualEntry = true;
+    component.updateManual('other');
+    component.select('B');
+    fixture.detectChanges();
+    expect(component.value().selection).toBe('B');
+    expect(component.value().manual).toBe('');
+  });
 });

--- a/src/app/shared/controls/single-choice/single-choice.ts
+++ b/src/app/shared/controls/single-choice/single-choice.ts
@@ -70,9 +70,11 @@ export class SingleChoice {
 
   select(option: string): void {
     this.selected.set(option);
+    this.manualValue.set('');
   }
 
   updateManual(val: string): void {
     this.manualValue.set(val);
+    this.selected.set('');
   }
 }


### PR DESCRIPTION
## Summary
- deselect radio option when manual value entered
- clear manual text when a predefined option is chosen
- test manual entry selection interplay
- document fix

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_684fe5ad5fd8833393dfdd98e07fb7a2