### PR TITLE
Add custom label for manual choice

### DIFF
--- a/src/app/shared/controls/multiple-choice/multiple-choice.html
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.html
@@ -18,6 +18,7 @@
 }
 @if (allowManualEntry) {
   <label class="manual">
+    {{ manualLabel }}
     <input
       type="text"
       [value]="manualValue()"

--- a/src/app/shared/controls/multiple-choice/multiple-choice.spec.ts
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.spec.ts
@@ -37,4 +37,15 @@ describe('MultipleChoice', () => {
     fixture.detectChanges();
     expect((component as any).manualError()).toContain('Minimum length');
   });
+
+  it('should render manual label', () => {
+    component.allowManualEntry = true;
+    fixture.detectChanges();
+    let label = fixture.nativeElement.querySelector('label.manual') as HTMLElement;
+    expect(label.textContent).toContain('Other');
+    component.manualLabel = 'Custom';
+    fixture.detectChanges();
+    label = fixture.nativeElement.querySelector('label.manual') as HTMLElement;
+    expect(label.textContent).toContain('Custom');
+  });
 });

--- a/src/app/shared/controls/multiple-choice/multiple-choice.ts
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.ts
@@ -18,6 +18,7 @@ export class MultipleChoice {
   @Input() required = false;
   @Input() minSelections = 0;
   @Input() allowManualEntry = false;
+  @Input() manualLabel = 'Other';
   @Input() manualMinLength = 0;
   @Input() manualMaxLength = Infinity;
 

--- a/src/app/shared/controls/single-choice/single-choice.html
+++ b/src/app/shared/controls/single-choice/single-choice.html
@@ -21,6 +21,7 @@
 }
 @if (allowManualEntry) {
   <label class="manual">
+    {{ manualLabel }}
     <input
       type="text"
       [value]="manualValue()"

--- a/src/app/shared/controls/single-choice/single-choice.spec.ts
+++ b/src/app/shared/controls/single-choice/single-choice.spec.ts
@@ -61,4 +61,15 @@ describe('SingleChoice', () => {
     expect(component.value().selection).toBe('B');
     expect(component.value().manual).toBe('');
   });
+
+  it('should render manual label', () => {
+    component.allowManualEntry = true;
+    fixture.detectChanges();
+    let label = fixture.nativeElement.querySelector('label.manual') as HTMLElement;
+    expect(label.textContent).toContain('Other');
+    component.manualLabel = 'Custom';
+    fixture.detectChanges();
+    label = fixture.nativeElement.querySelector('label.manual') as HTMLElement;
+    expect(label.textContent).toContain('Custom');
+  });
 });

--- a/src/app/shared/controls/single-choice/single-choice.ts
+++ b/src/app/shared/controls/single-choice/single-choice.ts
@@ -17,6 +17,7 @@ export class SingleChoice {
   @Input() options: string[] = [];
   @Input() required = false;
   @Input() allowManualEntry = false;
+  @Input() manualLabel = 'Other';
   @Input() manualMinLength = 0;
   @Input() manualMaxLength = Infinity;
 


### PR DESCRIPTION
## Summary
- support configurable label for manual options
- add tests for manual label rendering

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_b_684febef8c988333ba353011ee9754a6