### PR TITLE
Ensure choice controls validate after interaction

### DIFF
--- a/src/app/shared/controls/multiple-choice/multiple-choice.html
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.html
@@ -2,7 +2,7 @@
   class="options"
   role="group"
   [attr.aria-label]="name"
-  [attr.aria-describedby]="selectionError() ? selectionErrorId : null">
+  [attr.aria-describedby]="dirty() && selectionError() ? selectionErrorId : null">
   @for (option of options; track option) {
     <label>
       <input
@@ -13,7 +13,7 @@
     </label>
   }
 </div>
-@if (selectionError()) {
+@if (dirty() && selectionError()) {
   <p class="error" [id]="selectionErrorId">{{ selectionError() }}</p>
 }
 @if (allowManualEntry) {
@@ -23,10 +23,10 @@
       type="text"
       [value]="manualValue()"
       (input)="onManual($event)"
-      [attr.aria-invalid]="manualError() ? true : null"
-      [attr.aria-describedby]="manualError() ? manualErrorId : null" />
+      [attr.aria-invalid]="manualDirty() && manualError() ? true : null"
+      [attr.aria-describedby]="manualDirty() && manualError() ? manualErrorId : null" />
   </label>
-  @if (manualError()) {
+  @if (manualDirty() && manualError()) {
     <p class="error" [id]="manualErrorId">{{ manualError() }}</p>
   }
 }

--- a/src/app/shared/controls/multiple-choice/multiple-choice.spec.ts
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.spec.ts
@@ -56,4 +56,14 @@ describe('MultipleChoice', () => {
     label = fixture.nativeElement.querySelector('label.manual') as HTMLElement;
     expect(label.textContent).toContain('Custom');
   });
+
+  it('should not show errors before interaction', () => {
+    component.required = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.error')).toBeNull();
+    component.toggle('A', false);
+    fixture.detectChanges();
+    const error = fixture.nativeElement.querySelector('.error') as HTMLElement;
+    expect(error.textContent).toContain('Selection required');
+  });
 });

--- a/src/app/shared/controls/multiple-choice/multiple-choice.ts
+++ b/src/app/shared/controls/multiple-choice/multiple-choice.ts
@@ -21,6 +21,8 @@ export class MultipleChoice implements ChoiceControl<string[]> {
 
   protected readonly selectedOptions = signal<string[]>([]);
   protected readonly manualValue = signal('');
+  protected readonly dirty = signal(false);
+  protected readonly manualDirty = signal(false);
 
   readonly value = model<
     ChoiceControlValue & { selection: string[] }
@@ -72,6 +74,7 @@ export class MultipleChoice implements ChoiceControl<string[]> {
   }
 
   toggle(option: string, checked: boolean): void {
+    this.dirty.set(true);
     this.selectedOptions.update(values => {
       if (checked) {
         return values.includes(option) ? values : [...values, option];
@@ -81,6 +84,8 @@ export class MultipleChoice implements ChoiceControl<string[]> {
   }
 
   updateManual(val: string): void {
+    this.manualDirty.set(true);
+    this.dirty.set(true);
     this.manualValue.set(val);
   }
 }

--- a/src/app/shared/controls/single-choice/single-choice.html
+++ b/src/app/shared/controls/single-choice/single-choice.html
@@ -2,7 +2,7 @@
   class="options"
   role="radiogroup"
   [attr.aria-label]="name"
-  [attr.aria-describedby]="selectionError() ? selectionErrorId : null"
+  [attr.aria-describedby]="dirty() && selectionError() ? selectionErrorId : null"
 >
   @for (option of options; track option) {
     <label>
@@ -16,7 +16,7 @@
     </label>
   }
 </div>
-@if (selectionError()) {
+@if (dirty() && selectionError()) {
   <p class="error" [id]="selectionErrorId">{{ selectionError() }}</p>
 }
 @if (allowManualEntry) {
@@ -26,11 +26,11 @@
       type="text"
       [value]="manualValue()"
       (input)="onManual($event)"
-      [attr.aria-invalid]="manualError() ? true : null"
-      [attr.aria-describedby]="manualError() ? manualErrorId : null"
+      [attr.aria-invalid]="manualDirty() && manualError() ? true : null"
+      [attr.aria-describedby]="manualDirty() && manualError() ? manualErrorId : null"
     />
   </label>
-  @if (manualError()) {
+  @if (manualDirty() && manualError()) {
     <p class="error" [id]="manualErrorId">{{ manualError() }}</p>
   }
 }

--- a/src/app/shared/controls/single-choice/single-choice.spec.ts
+++ b/src/app/shared/controls/single-choice/single-choice.spec.ts
@@ -72,4 +72,14 @@ describe('SingleChoice', () => {
     label = fixture.nativeElement.querySelector('label.manual') as HTMLElement;
     expect(label.textContent).toContain('Custom');
   });
+
+  it('should not show errors before interaction', () => {
+    component.required = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.error')).toBeNull();
+    component.updateManual('');
+    fixture.detectChanges();
+    const error = fixture.nativeElement.querySelector('.error') as HTMLElement;
+    expect(error.textContent).toContain('Selection required');
+  });
 });

--- a/src/app/shared/controls/single-choice/single-choice.ts
+++ b/src/app/shared/controls/single-choice/single-choice.ts
@@ -20,6 +20,8 @@ export class SingleChoice implements ChoiceControl<string> {
 
   protected readonly selected = signal('');
   protected readonly manualValue = signal('');
+  protected readonly dirty = signal(false);
+  protected readonly manualDirty = signal(false);
 
   readonly value = model<
     ChoiceControlValue & { selection: string }
@@ -67,11 +69,14 @@ export class SingleChoice implements ChoiceControl<string> {
   }
 
   select(option: string): void {
+    this.dirty.set(true);
     this.selected.set(option);
     this.manualValue.set('');
   }
 
   updateManual(val: string): void {
+    this.manualDirty.set(true);
+    this.dirty.set(true);
     this.manualValue.set(val);
     this.selected.set('');
   }


### PR DESCRIPTION
## Summary
- track dirty state in multiple-choice and single-choice components
- display validation errors only when fields have been interacted with
- cover new behaviour with unit tests

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_684ffc38f0688333bee339e307bb148e