### PR TITLE
Fix signals and shell imports

### DIFF
--- a/src/app/lists/components/item-form/item-form.component.ts
+++ b/src/app/lists/components/item-form/item-form.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Output, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, output, signal } from '@angular/core';
 
 @Component({
   selector: 'app-item-form',
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, Output, input, output } from '@angu
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ItemFormComponent {
-  readonly name = input('');
+  readonly name = signal('');
   readonly add = output<string>();
 
   onSubmit(): void {

--- a/src/app/notifications/components/reminder-scheduler/reminder-scheduler.component.ts
+++ b/src/app/notifications/components/reminder-scheduler/reminder-scheduler.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Output, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, output, signal } from '@angular/core';
 
 @Component({
   selector: 'app-reminder-scheduler',
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, Output, input, output } from '@angu
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ReminderSchedulerComponent {
-  readonly time = input('');
+  readonly time = signal('');
   readonly scheduled = output<string>();
 
   schedule(): void {

--- a/src/app/shell/components/connection-status/connection-status.component.html
+++ b/src/app/shell/components/connection-status/connection-status.component.html
@@ -1,4 +1,4 @@
-@if (connected) {
+@if (connected()) {
   <span>Online</span>
 } @else {
   <span>Offline</span>

--- a/src/app/shell/components/connection-status/connection-status.component.ts
+++ b/src/app/shell/components/connection-status/connection-status.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 @Component({
   selector: 'app-connection-status',
@@ -7,5 +7,5 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConnectionStatusComponent {
-  @Input() connected = true;
+  readonly connected = input(true);
 }

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -1,11 +1,19 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { HeaderComponent } from './components/header/header.component';
+import { NavigationMenuComponent } from './components/navigation-menu/navigation-menu.component';
+import { ConnectionStatusComponent } from './components/connection-status/connection-status.component';
 
 @Component({
   selector: 'app-shell',
   templateUrl: './shell.component.html',
   styleUrl: './shell.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterOutlet],
+  imports: [
+    RouterOutlet,
+    HeaderComponent,
+    NavigationMenuComponent,
+    ConnectionStatusComponent,
+  ],
 })
 export class ShellComponent {}


### PR DESCRIPTION
## Summary
- update components to use `signal()` instead of `input()` for local state
- import header, navigation menu and connection status into ShellComponent
- convert connection status to `input()` signal

## Testing
- `npx ng build --configuration=development`
- `npx ng test --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_b_685a316036888333a55a00ebdc9f66a0