### PR TITLE
Add front-end task coverage summary

### DIFF
--- a/docs/tasks/summary.md
+++ b/docs/tasks/summary.md
@@ -1,0 +1,32 @@
+# Task Coverage Summary
+
+This document reviews `task-01` through `task-12` from a front‑end perspective and determines how well they implement the features outlined in the PRD and SRS.
+
+## Overview of Tasks
+
+1. **PWA Shell** – sets up an Angular 20 PWA with a service worker, connection status service and an offline banner. [task-01](task-01.md)
+2. **Authentication** – implements login/signup pages, an AuthService with JWT storage and an HTTP interceptor. [task-02](task-02.md)
+3. **ListService** – provides offline storage, real‑time synchronization and queueing of actions while offline. [task-03](task-03.md)
+4. **List Overview Page** – shows existing lists and supports creation of new lists. [task-04](task-04.md)
+5. **ItemService** – manages list items with IndexedDB persistence, WebSocket updates and offline queueing. [task-05](task-05.md)
+6. **Item Form & Item List** – components to add, edit and display items grouped by category. [task-06](task-06.md)
+7. **Category Service & Filter** – fetches categories and filters items by category. [task-07](task-07.md)
+8. **Suggestion Service & Panel** – suggests frequently purchased items and allows quick addition. [task-08](task-08.md)
+9. **Notification Service & Settings Page** – handles push permissions and reminder scheduling. [task-09](task-09.md)
+10. **Sync Status Component** – visualizes connectivity and sync state in the header. [task-10](task-10.md)
+11. **Accessibility & Performance Audit** – audits pages, resolves issues and adds automated checks. [task-11](task-11.md)
+12. **End‑to‑End Testing** – Cypress tests for offline and real‑time scenarios. [task-12](task-12.md)
+
+## Coverage Assessment
+
+The tasks collectively address the core features specified in the PRD and SRS:
+
+- **Offline functionality** – handled by the service worker, ListService and ItemService which queue actions while offline.
+- **Real‑time synchronization** – ListService and ItemService subscribe to WebSocket updates and sync when back online.
+- **Item categorization and suggestions** – CategoryService and SuggestionService provide category filtering and recommendations.
+- **Notifications and reminders** – NotificationService manages push subscriptions and reminder preferences.
+- **Accessibility and performance** – dedicated audit task ensures WCAG 2.1 AA compliance and performance budgets.
+
+However, a dedicated page that composes the item list, form, category filter and suggestion panel (i.e. a **List Detail Page**) is not explicitly described. Task‑06 introduces the necessary components, but no task assembles them into a page. Router configuration and overall navigation beyond the header from task‑01 are also not spelled out. These areas may require additional tasks.
+
+Overall, tasks 01‑12 cover nearly all front‑end functionality for the collaborative shopping list application, with the minor gap noted above regarding the List Detail page composition and navigation setup.


### PR DESCRIPTION
## Summary
- analyze tasks and create summary of coverage for front-end features

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685a5e23c4d883339bcb3221a4f074ba