### PR TITLE
Add request model for Hcp values

### DIFF
--- a/service/index.ts
+++ b/service/index.ts
@@ -103,6 +103,7 @@ export type { SaveDataResponse } from './models/SaveDataResponse';
 export type { SaveDeviceDataRequest } from './models/SaveDeviceDataRequest';
 export type { SaveDeviceDataResponse } from './models/SaveDeviceDataResponse';
 export type { SaveParameterDataRequest } from './models/SaveParameterDataRequest';
+export type { GetHcpPatientValuesRequest } from './models/GetHcpPatientValuesRequest';
 export type { SendEmailRequest } from './models/SendEmailRequest';
 export type { SystemUserSelfUpdateRequest } from './models/SystemUserSelfUpdateRequest';
 export type { TemporaryPatientResponse } from './models/TemporaryPatientResponse';

--- a/service/models/GetHcpPatientValuesRequest.ts
+++ b/service/models/GetHcpPatientValuesRequest.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type GetHcpPatientValuesRequest = {
+  patientId: number;
+  xOrganizationId: any;
+  parameterKey?: Array<string>;
+  reference?: string;
+  page?: number;
+  pageSize?: number;
+  orderBy?: string;
+  direction?: string;
+  startTimestamp?: number;
+  endTimestamp?: number;
+  q?: string;
+};

--- a/service/services/HcpHcpApiService.ts
+++ b/service/services/HcpHcpApiService.ts
@@ -18,6 +18,7 @@ import type { QueryParameterValuesResponse } from '../models/QueryParameterValue
 import type { QueryParameterValuesSummaryResponse } from '../models/QueryParameterValuesSummaryResponse';
 import type { SaveDataResponse } from '../models/SaveDataResponse';
 import type { SaveParameterDataRequest } from '../models/SaveParameterDataRequest';
+import type { GetHcpPatientValuesRequest } from '../models/GetHcpPatientValuesRequest';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 @Injectable({
@@ -149,19 +150,7 @@ export class HcpHcpApiService {
     startTimestamp,
     endTimestamp,
     q,
-  }: {
-    patientId: number,
-    xOrganizationId: any,
-    parameterKey?: Array<string>,
-    reference?: string,
-    page?: number,
-    pageSize?: number,
-    orderBy?: string,
-    direction?: string,
-    startTimestamp?: number,
-    endTimestamp?: number,
-    q?: string,
-  }): Observable<QueryParameterValuesResponse> {
+  }: GetHcpPatientValuesRequest): Observable<QueryParameterValuesResponse> {
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/hcp/patient/{patientId}/values',
@@ -204,19 +193,7 @@ export class HcpHcpApiService {
     startTimestamp,
     endTimestamp,
     q,
-  }: {
-    patientId: number,
-    xOrganizationId: any,
-    parameterKey?: Array<string>,
-    reference?: string,
-    page?: number,
-    pageSize?: number,
-    orderBy?: string,
-    direction?: string,
-    startTimestamp?: number,
-    endTimestamp?: number,
-    q?: string,
-  }): Observable<QueryParameterValuesSummaryResponse> {
+  }: GetHcpPatientValuesRequest): Observable<QueryParameterValuesSummaryResponse> {
     return __request(OpenAPI, this.http, {
       method: 'GET',
       url: '/api/hcp/patient/{patientId}/parameter-values-summary',


### PR DESCRIPTION
## Summary
- introduce `GetHcpPatientValuesRequest` model
- use new model in `HcpHcpApiService`
- export the new request type

## Testing
- `npm test` *(fails: Some of your tests did a full page reload and 1 FAILED)*

------
https://chatgpt.com/codex/tasks/task_b_685b206fd63c8333874d98acadf290d0